### PR TITLE
Allow custom http server and skip failures on internet unavailability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
+| `file_server` | `https://github.com/prometheus/node_exporter/releases/download` | Location of the release artifacts. Required artifacts as hosted [here](https://github.com/prometheus/node_exporter/releases), should be available on the custom file server under `v<version_number>` directory. |
 | `node_exporter_version` | 0.17.0 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,11 @@ node_exporter_enabled_collectors:
 #      ignored-fs-types: "^(sys|proc|auto)fs$"
 
 node_exporter_disabled_collectors: []
+
+
+## Custom vars for local installation
+# Should have the required artifacts hosted from - https://github.com/prometheus/node_exporter/releases
+# Example:
+#   original_url: https://github.com/prometheus/node_exporter/releases/download/v0.18.1/node_exporter-0.18.1.linux-amd64.tar.gz should be downloadable
+#   custom_url: http://127.0.0.1:8080/v0.18.1/node_exporter-0.18.1.linux-amd64.tar.gz should be downloadable
+file_server: https://github.com/prometheus/node_exporter/releases/download

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,3 +27,4 @@
   when:
     - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
+  ignore_errors: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,6 +8,7 @@
   retries: 5
   delay: 2
   with_items: "{{ node_exporter_dependencies }}"
+  ignore_errors: yes
 
 - name: Create the node_exporter group
   group:
@@ -30,7 +31,7 @@
 - name: Download node_exporter binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+    url: "{{ file_server }}/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     checksum: "sha256:{{ node_exporter_checksum }}"
   register: _download_binary

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -52,7 +52,7 @@
 
 - name: Get checksum list from github
   set_fact:
-    _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+    _checksums: "{{ lookup('url', file_server + '/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
   run_once: true
 
 - name: "Get checksum for {{ go_arch }} architecture"


### PR DESCRIPTION
* Allow custom web server to be passed instead of default github.com
for hosting relase artifacts
* Ignore any errors encountered while installing python-libselinux module
due to unavailability of internet