### PR TITLE
Enable selinux deps installation from custom file server

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,4 +27,3 @@
   when:
     - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
-  ignore_errors: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,17 @@
   with_items: "{{ node_exporter_dependencies }}"
   ignore_errors: yes
 
+- name: Install dependencies [offline or from local file server]
+  package:
+    name: "{{ item }}"
+    state: present
+  register: _offline_install_dep_packages
+  until: _offline_install_dep_packages is success
+  retries: 5
+  delay: 2
+  with_items: "{{ offline_dependencies }}"
+  when: _install_dep_packages is failed and offline_dependencies is defined
+
 - name: Create the node_exporter group
   group:
     name: "{{ node_exporter_system_group }}"

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -2,3 +2,17 @@
 node_exporter_dependencies:
   - libselinux-python
   - policycoreutils-python
+
+## If internet is not available to install the above mentioned dependencies, then fetch them (and their dependencies) from the hosted file server
+offline_dependencies:
+  - "{{ file_server }}/libselinux-python-2.5-14.1.el7.x86_64.rpm"
+  - "{{ file_server }}/audit-libs-python-2.8.4-4.el7.x86_64.rpm"
+  - "{{ file_server }}/checkpolicy-2.5-8.el7.x86_64.rpm"
+  - "{{ file_server }}/libcgroup-0.41-20.el7.x86_64.rpm"
+  - "{{ file_server }}/libselinux-python-2.5-14.1.el7.x86_64.rpm"
+  - "{{ file_server }}/libsemanage-2.5-14.el7.x86_64.rpm"
+  - "{{ file_server }}/libsemanage-python-2.5-14.el7.x86_64.rpm"
+  - "{{ file_server }}/python-IPy-0.75-6.el7.noarch.rpm"
+  - "{{ file_server }}/setools-libs-3.3.8-4.el7.x86_64.rpm"
+  - "{{ file_server }}/policycoreutils-python-2.5-29.el7_6.1.x86_64.rpm"
+  - "{{ file_server }}/policycoreutils-python-2.5-29.el7.x86_64.rpm"


### PR DESCRIPTION
If internet is not available on the target machine then install the
dependencies (selinux python modules) from the offline file server
which hosts the node exporter binaries too.